### PR TITLE
Possibility to specify more than one decimal separator

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 		<script type="text/javascript">
 			$(function(){
 				$('#int').numberMask({beforePoint:2});
-				$('#float').numberMask({type:'float',afterPoint:4,defaultValueInput:'10,1',decimalMark:[',']});
+				$('#float').numberMask({type:'float',afterPoint:4,defaultValueInput:'10,1',decimalMark:','});
 				$('#float2').numberMask({type:'float',afterPoint:4,defaultValueInput:'10.1',decimalMark:['.',',']});
 				$('#float3').numberMask({pattern:/^\d+\.{0,1}\d*$|^\d+,{0,1}\d*$/});
 				$('#negative').numberMask({pattern:/^-{0,1}\d*$/});
@@ -19,7 +19,7 @@
 	<form action='irr.ru'>
 		<table>
 			<tr><td><label for='int'>Type integer mask xx $('#int').numberMask({beforePoint:2});</label></td><td><input id='int' type='text'></td></tr>
-			<tr><td><label for='float'>Type float mask xx,xxxx $('#float').numberMask({type:'float',afterPoint:4,defaultValueInput:'10,1',decimalMark:[',']});</label></td><td><input id='float' type='text'></td></tr>
+			<tr><td><label for='float'>Type float mask xx,xxxx $('#float').numberMask({type:'float',afterPoint:4,defaultValueInput:'10,1',decimalMark:','});</label></td><td><input id='float' type='text'></td></tr>
 			<tr><td><label for='float2'>Type float mask xx.xxxx $('#float2').numberMask({type:'float',afterPoint:4,defaultValueInput:'10.1',decimalMark:['.',',']});</label></td><td><input id='float2' type='text'></td></tr>
 			<tr><td><label for='float3'>Type float mask separator may be '.' or ','   $('#float3').numberMask({pattern:/^\d+\.{0,1}\d*$|^\d+,{0,1}\d*$/});</label></td><td><input id='float3' type='text'></td></tr>
 			<tr><td><label for='negative'>Mask for negative number $('#negative').numberMask({pattern:/^-{0,1}\d*$/});</label></td><td><input id='negative' type='text'></td></tr>

--- a/jquery.numberMask.js
+++ b/jquery.numberMask.js
@@ -134,6 +134,10 @@
 			}
 		this.bind('keypress',onKeyPress).bind('keyup',onKeyUp).bind('blur',onBlur);
 		if (options) {
+			if (options.decimalMark){
+				if ($.type(options.decimalMark) === "string")
+					options.decimalMark = [options.decimalMark];
+			}
 			$.extend(settings, options);
 		}
 		return this;


### PR DESCRIPTION
Using this plugin I've faced a problem to support both ',' and '.' as a decimal separator. So I've modified a code to specify an array of separators instead of one value.
